### PR TITLE
Use given params, if any, in Client.make_call

### DIFF
--- a/labarchivespy/client.py
+++ b/labarchivespy/client.py
@@ -109,6 +109,8 @@ class Client():
             expires=expires,
             sig=signature
         )
+        if param_string:
+            query_url += "&" + param_string
         response = requests.get(query_url)
 
         return response


### PR DESCRIPTION
Thanks for sharing this.  I had to make just one small change to `Client.make_call` so that it would use the `params` argument, since that's not handled in the URL format string.